### PR TITLE
Implemented a ByteBuf Backed CodedOutputStream

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -42,6 +42,11 @@
       <artifactId>truth</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-buffer</artifactId>
+      <version>4.1.51.Final</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -107,6 +107,11 @@
         <version>1.0.1</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-buffer</artifactId>
+        <version>4.1.51.Final</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Added an implementation for a ByteBuf backed CodedOutputStream. This will remove internal byte array allocations when serializing a method using `writeTo`